### PR TITLE
Refactor keyboard events handling

### DIFF
--- a/frontend/src/board.rs
+++ b/frontend/src/board.rs
@@ -64,9 +64,7 @@ impl Component for Board {
         let onmousemove = ctx.link().callback(
             |e: MouseEvent| Msg::MouseMove(Coords { x: e.client_x(), y: e.client_y() })
         );
-        let onkeydown = ctx.link().callback(
-            |e: KeyboardEvent| Msg::KeyDown(e)
-        );
+        let onkeydown = ctx.link().callback(Msg::KeyDown);
         let onmouseup = ctx.link().callback(|_: MouseEvent| Msg::MouseLeftUp);
         html!{
             <div tabindex="0"

--- a/frontend/src/board.rs
+++ b/frontend/src/board.rs
@@ -65,7 +65,7 @@ impl Component for Board {
             |e: MouseEvent| Msg::MouseMove(Coords { x: e.client_x(), y: e.client_y() })
         );
         let onkeydown = ctx.link().callback(
-            |e: KeyboardEvent| Msg::KeyDown(e.key())
+            |e: KeyboardEvent| Msg::KeyDown(e)
         );
         let onmouseup = ctx.link().callback(|_: MouseEvent| Msg::MouseLeftUp);
         html!{
@@ -105,8 +105,8 @@ impl Component for Board {
                 self.select_block(id);
                 true
             },
-            Msg::KeyDown(key) => {
-                match key.as_str() {
+            Msg::KeyDown(event) => {
+                match event.key().as_str() {
                     "n" => {
                         let id = self.block_id_gen.next().unwrap();
                         self.blocks.insert(id, Block::new(id, self.mouse_position.clone()));

--- a/frontend/src/board/block.rs
+++ b/frontend/src/board/block.rs
@@ -1,7 +1,5 @@
 mod block_id;
 
-use std::fmt::format;
-
 pub use block_id::{BlockId, BlockIdGenerator};
 use yew::prelude::{Html, html};
 

--- a/frontend/src/board/message.rs
+++ b/frontend/src/board/message.rs
@@ -1,3 +1,5 @@
+use yew::KeyboardEvent;
+
 use super::{BlockId, Coords};
 
 pub enum Msg {
@@ -5,5 +7,5 @@ pub enum Msg {
     MouseLeftUp,
     MouseLeftDownBlock(BlockId),
     // maybe we should change it to key codes for simpler matching
-    KeyDown(String),
+    KeyDown(KeyboardEvent),
 }


### PR DESCRIPTION
Сделал так, чтобы в сообщении хранился KeyboardEvent, а не строчка с клавишей, чтобы была возможность обрабатывать управляющие клавиши (Ctrl, Alt, Shift).